### PR TITLE
Dependancy support for Ubuntu 20.04+

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,10 +18,9 @@ sudo apt dist-upgrade -y
 sudo apt install -y apt-transport-https software-properties-common build-essential autoconf pkg-config make gcc g++ screen wget curl ntp fail2ban 
 
 sudo add-apt-repository -y ppa:chris-lea/redis-server
-sudo add-apt-repository -y ppa:bitcoin/bitcoin
 
 sudo apt update
-sudo apt install -y libdb4.8-dev libdb4.8++-dev libssl-dev libboost-all-dev libminiupnpc-dev libtool autotools-dev redis-server
+sudo apt install -y libdb5.3-dev libdb5.3++-dev libssl-dev libboost-all-dev libminiupnpc-dev libtool autotools-dev redis-server
 sudo apt install -y sudo git npm nodejs      
 
 sudo systemctl enable fail2ban


### PR DESCRIPTION
The ppa for bitcoin returns `404`. Where only two packages are depending on it. It can be avoided and is able to use a newer version